### PR TITLE
fix(notification): correctly extract iforte tickets from api response

### DIFF
--- a/src/domains/notification/jobs/send-iforte-ticket-reminder.job.ts
+++ b/src/domains/notification/jobs/send-iforte-ticket-reminder.job.ts
@@ -41,7 +41,8 @@ export class SendIforteTicketReminderJob extends BaseJob<Payload> {
         throw new Error(`Gagal mengambil tiket iForte: ${response.statusText}`);
       }
 
-      const tickets: IforteTicket[] = await response.json();
+      const responseData = await response.json();
+      const tickets: IforteTicket[] = responseData.results || [];
 
       if (tickets.length === 0) {
         logger.info('Tidak ada data tiket iForte.');


### PR DESCRIPTION
Fixes #5

### Changes:
- Extracted the `tickets` array from the `results` property of the NIS Gateway JSON response object.
- This prevents the `TypeError: tickets.filter is not a function` when processing tickets.