### PR TITLE
fix(zabbix): chunk api requests to prevent 500 error

### DIFF
--- a/src/domains/zabbix/jobs/sync-iforte-graphs.job.ts
+++ b/src/domains/zabbix/jobs/sync-iforte-graphs.job.ts
@@ -51,42 +51,54 @@ export class SyncIforteGraphsJob extends BaseJob<Payload> {
       token = await this.zabbixLogin();
       logger.info('Logged in to Zabbix successfully.');
 
-      // 2. Fetch graphs
-      const graphs = await this.zabbixGetGraphs(token);
-      logger.info(`Found ${graphs.length} graph(s) in Zabbix.`);
+      // 2. Fetch basic graph IDs (lightweight request)
+      const graphIds = await this.zabbixGetGraphIds(token);
+      logger.info(`Found ${graphIds.length} graph(s) matching filter in Zabbix.`);
 
-      // 3. Prepare data to sync
-      const syncData: SyncGraphData[] = graphs
-        .map((graph) => {
-          const firstItemName = graph.items?.[0]?.name ?? '';
-          const match = firstItemName.match(/(\d+):(\d+)/);
-          if (!match) return null;
-
-          return {
-            graphid: graph.graphid,
-            subscriberId: match[2],
-          };
-        })
-        .filter((item): item is SyncGraphData => item !== null);
-
-      logger.info(`Extracted ${syncData.length} valid items for synchronization.`);
-
-      if (syncData.length === 0) {
-        logger.warn('No valid items found to sync. Skipping.');
+      if (graphIds.length === 0) {
+        logger.warn('No graphs found. Skipping.');
         return;
       }
 
-      // 4. Batching (limit 64 per submit)
-      const BATCH_SIZE = 64;
-      for (let i = 0; i < syncData.length; i += BATCH_SIZE) {
-        const batch = syncData.slice(i, i + BATCH_SIZE);
-        const batchNumber = Math.floor(i / BATCH_SIZE) + 1;
+      // Process in chunks of 1000 to avoid Zabbix API memory exhaustion
+      const CHUNK_SIZE = 1000;
+      let totalValidItems = 0;
 
-        logger.info(`Syncing batch ${batchNumber}...`);
-        await this.syncToEndpoint(batch);
+      for (let i = 0; i < graphIds.length; i += CHUNK_SIZE) {
+        const chunk = graphIds.slice(i, i + CHUNK_SIZE);
+        const chunkNumber = Math.floor(i / CHUNK_SIZE) + 1;
+        const totalChunks = Math.ceil(graphIds.length / CHUNK_SIZE);
+
+        logger.info(`Fetching details for chunk ${chunkNumber}/${totalChunks}...`);
+        const fullGraphs = await this.zabbixGetGraphsDetails(token, chunk);
+
+        // 3. Prepare data to sync
+        const syncData: SyncGraphData[] = fullGraphs
+          .map((graph) => {
+            const firstItemName = graph.items?.[0]?.name ?? '';
+            const match = firstItemName.match(/(\d+):(\d+)/);
+            if (!match) return null;
+
+            return {
+              graphid: graph.graphid,
+              subscriberId: match[2],
+            };
+          })
+          .filter((item): item is SyncGraphData => item !== null);
+
+        totalValidItems += syncData.length;
+
+        if (syncData.length > 0) {
+          // 4. Batching to sync endpoint (limit 64 per submit)
+          const BATCH_SIZE = 64;
+          for (let j = 0; j < syncData.length; j += BATCH_SIZE) {
+            const batch = syncData.slice(j, j + BATCH_SIZE);
+            await this.syncToEndpoint(batch);
+          }
+        }
       }
 
-      logger.info('All batches synchronized successfully.');
+      logger.info(`Successfully synchronized ${totalValidItems} valid items in total.`);
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : String(error);
       logger.error(`Failed to sync Zabbix graphs: ${errorMessage}`);
@@ -114,7 +126,8 @@ export class SyncIforteGraphsJob extends BaseJob<Payload> {
     });
 
     if (!response.ok) {
-      throw new Error(`Zabbix HTTP error: ${response.status} ${response.statusText}`);
+      const body = await response.text();
+      throw new Error(`Zabbix HTTP error: ${response.status} ${response.statusText}. Body: ${body}`);
     }
 
     const data: ZabbixRPCResponse<T> = await response.json();
@@ -139,13 +152,27 @@ export class SyncIforteGraphsJob extends BaseJob<Payload> {
     });
   }
 
-  private async zabbixGetGraphs(sessionid: string): Promise<ZabbixGraph[]> {
+  private async zabbixGetGraphIds(sessionid: string): Promise<string[]> {
+    const graphs = await this.zabbixRequest<{graphid: string}[]>(
+      'graph.get',
+      {
+        output: ['graphid'],
+        search: { name: ENV.IFORTE_ZABBIX_GRAPH_NAME_FILTER },
+        startSearch: true,
+        sortfield: 'graphid',
+        sortOrder: 'ASC',
+      },
+      sessionid,
+    );
+    return graphs.map((g) => g.graphid);
+  }
+
+  private async zabbixGetGraphsDetails(sessionid: string, graphids: string[]): Promise<ZabbixGraph[]> {
     return this.zabbixRequest<ZabbixGraph[]>(
       'graph.get',
       {
         output: ['graphid', 'name'],
-        search: { name: ENV.IFORTE_ZABBIX_GRAPH_NAME_FILTER },
-        startSearch: true,
+        graphids,
         selectItems: ['name'],
         sortfield: 'graphid',
         sortOrder: 'ASC',


### PR DESCRIPTION
Zabbix API ran out of memory when querying all 38k+ graphs with selectItems. This changes the logic to fetch IDs first, then batch retrieve details in chunks of 1000. This also resolves the fetch issue by falling back to items[0].name safely.