### PR TITLE
feat: tambahkan nomor urut pada list tiket reminder WhatsApp

### DIFF
--- a/src/domains/notification/jobs/send-fbstar-reminder.job.ts
+++ b/src/domains/notification/jobs/send-fbstar-reminder.job.ts
@@ -82,7 +82,7 @@ export class SendFbstarReminderJob extends BaseJob<Payload> {
       tickets.sort((a, b) => a.timestamp_unix - b.timestamp_unix);
 
       const messageLines = tickets.map(
-        ({ ticket_number, circuit_id, category, age_hours }) => {
+        ({ ticket_number, circuit_id, category, age_hours }, index) => {
           let alertIcon = '';
           if (age_hours >= 24) {
             alertIcon = '🚨';
@@ -96,7 +96,7 @@ export class SendFbstarReminderJob extends BaseJob<Payload> {
             durationText = `${days}+ hari`;
           }
 
-          return `- ${alertIcon}${ticket_number} ${circuit_id} ${category} ${durationText}`;
+          return `${index + 1}. ${alertIcon}${ticket_number} ${circuit_id} ${category} ${durationText}`;
         },
       );
 

--- a/src/domains/notification/jobs/send-iforte-ticket-reminder.job.ts
+++ b/src/domains/notification/jobs/send-iforte-ticket-reminder.job.ts
@@ -64,7 +64,7 @@ export class SendIforteTicketReminderJob extends BaseJob<Payload> {
         return new Date(a.insert_time).getTime() - new Date(b.insert_time).getTime();
       });
 
-      const messageLines = openTickets.map((ticket) => {
+      const messageLines = openTickets.map((ticket, index) => {
         const insertDate = new Date(ticket.insert_time);
         const ageHours = Math.floor((Date.now() - insertDate.getTime()) / (1000 * 3600));
 
@@ -83,7 +83,7 @@ export class SendIforteTicketReminderJob extends BaseJob<Payload> {
           durationText = `${days}+ hari`;
         }
 
-        return `- ${alertIcon}${acIcon}${ticket.customer_id}:${ticket.subscriber_id} ${ticket.subscriber_name} ${ticket.ticket_subject} ${durationText}`;
+        return `${index + 1}. ${alertIcon}${acIcon}${ticket.customer_id}:${ticket.subscriber_id} ${ticket.subscriber_name} ${ticket.ticket_subject} ${durationText}`;
       });
 
       const fullMessage = `Mohon dibantu tindak lanjut tiket berikut ini:\n\n${messageLines.join('\n')}`;


### PR DESCRIPTION
## Ringkasan

Menambahkan nomor urut pada list tiket di pesan reminder WhatsApp agar tim lebih mudah mereferensikan tiket tertentu saat berdiskusi.

## Perubahan

- **`SendFbstarReminderJob`**: format list diubah dari `- ` menjadi `1. `, `2. `, dst
- **`SendIforteTicketReminderJob`**: format list diubah dari `- ` menjadi `1. `, `2. `, dst

## Contoh Output

```
Mohon dibantu tindak lanjut tiket berikut ini:

1. 🚨💎CUST001:123 PT ABC Internet Putus 26 jam
2. ⚠️CUST002:456 CV XYZ Speed Lambat 20 jam
3. CUST003:789 PT DEF Request Setting 5 jam
```

Closes #8