### PR TITLE
feat: support custom WhatsApp target number via NATS payload

### DIFF
--- a/src/domains/notification/jobs/send-fbstar-reminder.job.ts
+++ b/src/domains/notification/jobs/send-fbstar-reminder.job.ts
@@ -4,7 +4,9 @@ import { ENV } from '../../../config/env';
 import { BaseJob } from '../../../core/base-job';
 import { logger } from '../../../core/logger';
 
-const PayloadSchema = z.object({}); // Empty payload, trigger manually
+const PayloadSchema = z.object({
+  to: z.string().optional(),
+});
 
 type Payload = z.infer<typeof PayloadSchema>;
 
@@ -15,7 +17,7 @@ export class SendFbstarReminderJob extends BaseJob<Payload> {
     return PayloadSchema.parse(data);
   }
 
-  protected async handle(_payload: Payload, _msg: JsMsg): Promise<void> {
+  protected async handle(payload: Payload, _msg: JsMsg): Promise<void> {
     logger.info('Mulai mengambil data tiket FBStar dari Prometheus...');
 
     try {
@@ -112,7 +114,7 @@ export class SendFbstarReminderJob extends BaseJob<Payload> {
           'Content-Type': 'application/json',
         },
         body: JSON.stringify({
-          to: ENV.WA_FBSTAR_TARGET_NUMBER,
+          to: payload.to ?? ENV.WA_FBSTAR_TARGET_NUMBER,
           body: 'text',
           text: fullMessage,
         }),

--- a/src/domains/notification/jobs/send-iforte-ticket-reminder.job.ts
+++ b/src/domains/notification/jobs/send-iforte-ticket-reminder.job.ts
@@ -4,7 +4,9 @@ import { ENV } from '../../../config/env';
 import { BaseJob } from '../../../core/base-job';
 import { logger } from '../../../core/logger';
 
-const PayloadSchema = z.object({});
+const PayloadSchema = z.object({
+  to: z.string().optional(),
+});
 
 type Payload = z.infer<typeof PayloadSchema>;
 
@@ -26,7 +28,7 @@ export class SendIforteTicketReminderJob extends BaseJob<Payload> {
     return PayloadSchema.parse(data);
   }
 
-  protected async handle(_payload: Payload, _msg: JsMsg): Promise<void> {
+  protected async handle(payload: Payload, _msg: JsMsg): Promise<void> {
     logger.info('Mulai mengambil data tiket iForte dari NIS Gateway...');
 
     try {
@@ -97,7 +99,7 @@ export class SendIforteTicketReminderJob extends BaseJob<Payload> {
           'Content-Type': 'application/json',
         },
         body: JSON.stringify({
-          to: ENV.WA_IFORTE_TARGET_NUMBER,
+          to: payload.to ?? ENV.WA_IFORTE_TARGET_NUMBER,
           body: 'text',
           text: fullMessage,
         }),


### PR DESCRIPTION
## Ringkasan

Tambahkan field opsional `to` pada payload NATS agar nomor tujuan WhatsApp bisa di-override per message.

## Perubahan

- **`SendFbstarReminderJob`**: payload `{to?: string}`, fallback ke `ENV.WA_FBSTAR_TARGET_NUMBER`
- **`SendIforteTicketReminderJob`**: payload `{to?: string}`, fallback ke `ENV.WA_IFORTE_TARGET_NUMBER`

## Contoh

```bash
# Default
nats pub STREAM.notification.reminder.fbstar '{}'

# Custom target
nats pub STREAM.notification.reminder.fbstar '{"to": "6281234567890"}'
```

Closes #10