### PR TITLE
feat: add SendEmployeeTicketSummaryJob for daily ticket distribution reminder

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,3 +32,9 @@ WA_API_URL=https://api.whatsapp.example.com/v2/messages
 WA_API_TOKEN=your_wa_api_token
 WA_FBSTAR_TARGET_NUMBER=your_fbstar_target_number
 WA_IFORTE_TARGET_NUMBER=your_iforte_target_number
+
+# Notification Job (Employee Ticket Summary)
+NIS_EMPLOYEE_SUMMARY_URL=https://transit.is5x.nusa.net.id/nis-gateway/ticket/employee-summary
+WA_TICKET_SUMMARY_TARGET_NUMBER=your_ticket_summary_target_number
+DEFAULT_DEPARTMENT_ID=34
+DEFAULT_EXCLUDED_EMPLOYEE_IDS=0200911,0202616

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -30,6 +30,12 @@ const envSchema = z.object({
   WA_API_TOKEN: z.string().min(1),
   WA_FBSTAR_TARGET_NUMBER: z.string().min(1),
   WA_IFORTE_TARGET_NUMBER: z.string().min(1),
+
+  // Notification Job (Employee Ticket Summary)
+  NIS_EMPLOYEE_SUMMARY_URL: z.string().url(),
+  WA_TICKET_SUMMARY_TARGET_NUMBER: z.string().min(1),
+  DEFAULT_DEPARTMENT_ID: z.coerce.number().int().default(34),
+  DEFAULT_EXCLUDED_EMPLOYEE_IDS: z.string().default(''),
 });
 
 const parsed = envSchema.safeParse(process.env);

--- a/src/domains/notification/jobs/send-employee-ticket-summary.job.ts
+++ b/src/domains/notification/jobs/send-employee-ticket-summary.job.ts
@@ -1,0 +1,122 @@
+import type { JsMsg } from 'nats';
+import { z } from 'zod';
+import { ENV } from '../../../config/env';
+import { BaseJob } from '../../../core/base-job';
+import { logger } from '../../../core/logger';
+
+const PayloadSchema = z.object({
+  to: z.string().optional(),
+  target_date: z.string().optional(),
+  excluded_employee_ids: z.string().optional(),
+  department_id: z.coerce.number().int().optional(),
+});
+
+type Payload = z.infer<typeof PayloadSchema>;
+
+interface EmployeeSummary {
+  employee_id: string;
+  name: string;
+  total_tickets: number;
+  tickets: number[];
+}
+
+export class SendEmployeeTicketSummaryJob extends BaseJob<Payload> {
+  readonly subject = 'notification.reminder.employee-ticket-summary';
+
+  protected validatePayload(data: unknown): Payload {
+    return PayloadSchema.parse(data);
+  }
+
+  protected async handle(payload: Payload, _msg: JsMsg): Promise<void> {
+    logger.info('Mulai mengambil data summary tiket karyawan dari NIS Gateway...');
+
+    try {
+      // Default target_date ke kemarin (H-1)
+      const targetDate = payload.target_date ?? this.getYesterdayDate();
+
+      const departmentId = payload.department_id ?? ENV.DEFAULT_DEPARTMENT_ID;
+
+      const excludedEmployeeIds =
+        payload.excluded_employee_ids ?? ENV.DEFAULT_EXCLUDED_EMPLOYEE_IDS;
+
+      const url = new URL(ENV.NIS_EMPLOYEE_SUMMARY_URL);
+      url.searchParams.set('target_date', targetDate);
+      url.searchParams.set('department_id', departmentId.toString());
+      if (excludedEmployeeIds) {
+        url.searchParams.set('excluded_employee_ids', excludedEmployeeIds);
+      }
+
+      logger.info({ targetDate, departmentId, excludedEmployeeIds }, 'Parameter request');
+
+      const response = await fetch(url.toString(), {
+        headers: {
+          accept: 'application/json',
+          Authorization: `Bearer ${ENV.NIS_TOKEN}`,
+        },
+      });
+
+      if (!response.ok) {
+        throw new Error(`Gagal mengambil summary tiket: ${response.statusText}`);
+      }
+
+      const responseData = await response.json();
+      const employees: EmployeeSummary[] = responseData.results || [];
+
+      if (employees.length === 0) {
+        logger.info('Tidak ada data summary tiket karyawan.');
+        return;
+      }
+
+      const messageLines = employees.map((emp, index) => {
+        let alertIcon = '';
+        if (emp.total_tickets >= 10) {
+          alertIcon = '🚨';
+        } else if (emp.total_tickets >= 5) {
+          alertIcon = '⚠️';
+        }
+
+        const ticketList = emp.tickets.join(', ');
+        return `${index + 1}. ${alertIcon}${emp.name} (${emp.total_tickets} tiket)\n   ${ticketList}`;
+      });
+
+      const totalTickets = employees.reduce((sum, emp) => sum + emp.total_tickets, 0);
+
+      const fullMessage =
+        `📊 Summary Tiket Karyawan - ${targetDate}\n` +
+        `Total: ${totalTickets} tiket, ${employees.length} karyawan\n\n` +
+        `${messageLines.join('\n')}`;
+
+      logger.info(`Mengirim summary ${employees.length} karyawan ke WhatsApp...`);
+
+      const waResponse = await fetch(ENV.WA_API_URL, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${ENV.WA_API_TOKEN}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          to: payload.to ?? ENV.WA_TICKET_SUMMARY_TARGET_NUMBER,
+          body: 'text',
+          text: fullMessage,
+        }),
+      });
+
+      if (!waResponse.ok) {
+        const errorText = await waResponse.text();
+        throw new Error(`Gagal mengirim WhatsApp: ${waResponse.statusText} - ${errorText}`);
+      }
+
+      const result = await waResponse.json();
+      logger.info({ result }, 'Berhasil mengirim summary tiket karyawan via WhatsApp.');
+    } catch (error) {
+      logger.error(error, 'Terjadi kesalahan saat memproses summary tiket karyawan');
+      throw error;
+    }
+  }
+
+  private getYesterdayDate(): string {
+    const yesterday = new Date();
+    yesterday.setDate(yesterday.getDate() - 1);
+    return yesterday.toISOString().split('T')[0];
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,6 +5,7 @@ import { SendFbstarReminderJob } from './domains/notification/jobs/send-fbstar-r
 import { SendWelcomeEmailJob } from './domains/notification/jobs/send-welcome-email.job';
 import { SyncIforteGraphsJob } from './domains/zabbix/jobs/sync-iforte-graphs.job';
 import { SendIforteTicketReminderJob } from './domains/notification/jobs/send-iforte-ticket-reminder.job';
+import { SendEmployeeTicketSummaryJob } from './domains/notification/jobs/send-employee-ticket-summary.job';
 
 async function bootstrap() {
   logger.info(`Menghubungkan ke NATS di ${ENV.NATS_URL}...`);
@@ -22,6 +23,7 @@ async function bootstrap() {
     new SyncIforteGraphsJob(),
     new SendFbstarReminderJob(),
     new SendIforteTicketReminderJob(),
+    new SendEmployeeTicketSummaryJob(),
   ];
 
   const opts = consumerOpts();


### PR DESCRIPTION
## Ringkasan

Job baru yang mengambil data summary distribusi tiket per karyawan dari NIS Gateway dan mengirim reminder via WhatsApp.

## File yang berubah

- `src/domains/notification/jobs/send-employee-ticket-summary.job.ts` — Job baru
- `src/config/env.ts` — ENV baru
- `src/main.ts` — Register job
- `.env.example` — Dokumentasi ENV

## Payload (semua opsional)

```json
{
  "to": "6281234567890",
  "target_date": "2026-07-06",
  "department_id": 34,
  "excluded_employee_ids": "0200911,0202616"
}
```

## Contoh Output WhatsApp

```
📊 Summary Tiket Karyawan - 2026-07-06
Total: 49 tiket, 18 karyawan

1. 🚨Morrys Bill Leonardo (10 tiket)
   473051, 472968, 471010, ...
2. ⚠️Jimmy Febrian (7 tiket)
   476225, 477788, ...
```

Closes #12